### PR TITLE
Don't halt when one or more png compression tools are missing

### DIFF
--- a/lib/transforms/optimizePngs.js
+++ b/lib/transforms/optimizePngs.js
@@ -17,13 +17,13 @@ try {
 module.exports = function (queryObj) {
     return function optimizePngs(assetGraph, cb) {
         if (!histogram) {
-            assetGraph.emit('error', new Error('optimizePngs: histogram not available, skipping quantization of png images.'));
+            assetGraph.emit('warn', new Error('optimizePngs: histogram not available, skipping quantization of png images.'));
         }
 
         Object.keys(progs).forEach(function (prog) {
             childProcess.execFile(prog, function (err) {
                 if (err && err.code === 127) {
-                    assetGraph.emit('error', new Error('optimizePngs: ' + prog + ' not installed. Install it to get smaller pngs'));
+                    assetGraph.emit('warn', new Error('optimizePngs: ' + prog + ' not installed. Install it to get smaller pngs'));
                     progs[prog] = false;
                 }
             });


### PR DESCRIPTION
assetGraph.emit('error', ...) is halting the whole program, but it seems from the text description that it's intended to keep going.
