### PR TITLE
processImages: Improve error handling on missing graphicsmagick

### DIFF
--- a/lib/transforms/processImages.js
+++ b/lib/transforms/processImages.js
@@ -85,26 +85,37 @@ module.exports = function (queryObj, options) {
                         filters[i].pipe(filters[i + 1]);
                     }
                     var chunks = [];
-                    filters[filters.length - 1].on('data', function (chunk) {
-                        chunks.push(chunk);
-                    }).on('end', function () {
-                        var rawSrc = Buffer.concat(chunks),
-                            newUrl = imageAsset.url.replace(/\/([^\.]*)([^\?]*)\?[^#]*/, '/$1.' + usedQueryString + '$2' + (leftOverQueryString ? '?' + leftOverQueryString : ''));
-                        if (targetContentType && targetContentType !== imageAsset.contentType) {
-                            var replacementImageAsset = assetGraph.createAsset({
-                                contentType: targetContentType,
-                                type: assetGraph.typeByContentType[targetContentType] || 'Image',
-                                url: newUrl,
-                                rawSrc: rawSrc
-                            });
-                            imageAsset.replaceWith(replacementImageAsset);
-                            replacementImageAsset.extension = replacementImageAsset.defaultExtension;
-                        } else {
-                            imageAsset.rawSrc = rawSrc;
-                            imageAsset.url = newUrl;
-                        }
-                        cb();
-                    });
+                    filters[filters.length - 1]
+                        .on('error', function (err) {
+                            if (err.message === 'The gm stream ended without emitting any data') {
+                                assetGraph.emit('warn', new Error('processImages: ' + imageAsset.url + '\nPlease install graphicsmagick to apply the following filters: ' + filtersAndTargetContentType.usedQueryStringFragments.join(', ')));
+                            } else {
+                                assetGraph.emit('error', err);
+                            }
+                            cb();
+                        })
+                        .on('data', function (chunk) {
+                            chunks.push(chunk);
+                        })
+                        .on('end', function () {
+                            var rawSrc = Buffer.concat(chunks),
+                                newUrl = imageAsset.url.replace(/\/([^\.]*)([^\?]*)\?[^#]*/, '/$1.' + usedQueryString + '$2' + (leftOverQueryString ? '?' + leftOverQueryString : ''));
+                            if (targetContentType && targetContentType !== imageAsset.contentType) {
+                                var replacementImageAsset = assetGraph.createAsset({
+                                    contentType: targetContentType,
+                                    type: assetGraph.typeByContentType[targetContentType] || 'Image',
+                                    url: newUrl,
+                                    rawSrc: rawSrc
+                                });
+                                imageAsset.replaceWith(replacementImageAsset);
+                                replacementImageAsset.extension = replacementImageAsset.defaultExtension;
+                            } else {
+                                imageAsset.rawSrc = rawSrc;
+                                imageAsset.url = newUrl;
+                            }
+                            cb();
+                        });
+
                     filters[0].end(imageAsset.rawSrc);
                 } else {
                     cb();


### PR DESCRIPTION
In the special case where https://github.com/papandreou/express-processimage/blob/master/lib/getFiltersAndTargetContentTypeFromQueryString.js#L69 is hit, processImages will emit a warning suggesting the user to install graphicsmagick, tell what filters where not applied and just move on.

If another error is emitted on the filter stream it will be emitted as an error in assetgraph.
