### PR TITLE
Use ngmin to annotage AngularJS minifier unsafe syntax

### DIFF
--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -68,6 +68,30 @@ module.exports = function (options) {
             .replaceRequireJsWithAlmond()
             .bundleRelations({type: 'HtmlScript', to: {type: 'JavaScript', isLoaded: true}, node: function (node) {return !node.hasAttribute('nobundle');}}, {strategyName: bundleStrategyName})
             .mergeIdenticalAssets({isLoaded: true, type: ['JavaScript', 'Css']}) // The bundling might produce several identical files, especially the 'oneBundlePerIncludingAsset' strategy.
+            .queue(function ngmin(assetGraph) {
+                var annotate,
+                    angular = assetGraph.findAssets({
+                        type: 'Html',
+                        isInline: false,
+                        isFragment: false
+                    }).some(function (asset) {
+                        var document = asset.parseTree;
+
+                        return document.body && (document.querySelector('[ng-app]') || document.querySelector('[class~="ng-app:"]'));
+                    });
+
+                if (angular) {
+                    annotate = require('ngmin').annotate;
+
+                    assetGraph.findAssets({
+                        type: 'JavaScript'
+                    }).forEach(function (asset) {
+                        asset.text = annotate(asset.text);
+                    });
+                }
+
+                return assetGraph;
+            })
             .removeNobundleAttribute({type: ['HtmlScript', 'HtmlStyle']})
             .if(inlineByRelationType.CssImage)
                 .inlineCssImagesWithLegacyFallback({type: 'Html', isInline: false, isFragment: false}, inlineByRelationType.CssImage)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jpegtran": "=0.0.4",
     "less": "=1.5.1",
     "memoizesync": "=0.2.0",
+    "ngmin": "=0.4.0",
     "optimist": "=0.2.6",
     "optipng": "=0.0.4",
     "passerror": "=1.0.0",


### PR DESCRIPTION
I'm tired of having assetgraph fail on building one of the mvc libraries that has most traction and is best at creating publicity.

This simply pulls in ngmin an runs it if there is an ng-app annotation in any html file.

Sadly this adds esprima to the stack and also adds a bit more runtime to the buildProduction transform. Seems worth it to me though.

Closes #39 
