### PR TITLE
change autoprefixer transform to be able to understand multiple conditions

### DIFF
--- a/bin/buildProduction
+++ b/bin/buildProduction
@@ -234,10 +234,6 @@ if (commandLineOptions.inlinesize) {
     inlineByRelationType.CssImage = 8192;
 }
 
-if (commandLineOptions.autoprefix && typeof commandLineOptions === 'string') {
-    commandLineOptions.autoprefix = [commandLineOptions.autoprefix];
-}
-
 (commandLineOptions.define ? _.flatten(_.flatten([commandLineOptions.define])) : []).forEach(function (define) {
     var matchDefine = define.match(/^(\w+)(?:=(.*))?$/);
     if (matchDefine) {

--- a/lib/transforms/autoprefixer.js
+++ b/lib/transforms/autoprefixer.js
@@ -9,7 +9,7 @@ var autoprefix = require('autoprefixer');
 
 module.exports = function (options) {
     // See https://github.com/ai/autoprefixer#browsers
-    var browsers = options;
+    var browsers = typeof options === 'string' ? options.split(/,\s*/) : options;
 
     return function autoprefixer(assetGraph) {
         assetGraph.findAssets({type: 'Css'}).forEach(function (cssAsset) {

--- a/test/autoprefixer.js
+++ b/test/autoprefixer.js
@@ -18,6 +18,26 @@ describe('transforms.autoprefixer', function () {
             .run(done);
     });
 
+    it('should handle a simple option case', function (done) {
+        expect(function () {
+            new AssetGraph({root: __dirname + '/autoprefixer/'})
+                .loadAssets('index.html')
+                .populate()
+                .autoprefixer('last 2 versions')
+                .run(done);
+        }, 'not to throw');
+    });
+
+    it('should handle a complex option case', function (done) {
+        expect(function () {
+            new AssetGraph({root: __dirname + '/autoprefixer/'})
+                .loadAssets('index.html')
+                .populate()
+                .autoprefixer('last 2 versions, ie > 8,ff > 28')
+                .run(done);
+        }, 'not to throw');
+    });
+
     it('should remove prefixfree.js and prefixfree.min.js', function (done) {
         new AssetGraph({root: __dirname + '/autoprefixer/'})
             .loadAssets('prefixfree.html')


### PR DESCRIPTION
buildProduction takes an option --autoprefix which is a string that defines the rules.

It was not possible to give more than one condition to autoprefixer because it doesn't understand a string with comma seperated values as input, and because the input string was wrapped in a list.

Now the input string is split on /,\s*/ and fed to autoprefixer as a list of individual conditions.
