### PR TITLE
fix node 0.8 Travis CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
-before_install: "sudo apt-get update && sudo apt-get install -y libcairo2-dev libjpeg8-dev libgif-dev optipng pngcrush pngquant libpango1.0-dev graphicsmagick libjpeg-turbo-progs inkscape && npm cache clean"
+before_install: "sudo apt-get update && sudo apt-get install -y libcairo2-dev libjpeg8-dev libgif-dev optipng pngcrush pngquant libpango1.0-dev graphicsmagick libjpeg-turbo-progs inkscape && npm install -g npm && npm cache clean"
 script: "npm run-script travis"
 
 notifications:


### PR DESCRIPTION
Due to outdated npm not understanding ^ in semver versions.

Ref: https://github.com/One-com/livestyle/commit/c19e7d6bdbf11aef81f04f7bac17ad4cf0de691c

Credit to @Munter 
