### PR TITLE
Make buildProduction work with static sites with multiple html files

### DIFF
--- a/bin/buildProduction
+++ b/bin/buildProduction
@@ -72,6 +72,11 @@ var optimist = require('optimist'),
             type: 'boolean',
             default: false
         })
+        .options('norecursive', {
+            describe: 'Don\'t follow local HTML anchors when populating the graph',
+            type: 'boolean',
+            deafult: false
+        })
         .options('nocompress', {
             describe: 'Prettifies HTML, CSS and Javascript for easier debugging',
             type: 'boolean',
@@ -302,6 +307,7 @@ new AssetGraph({root: rootUrl})
         asyncScripts: commandLineOptions.asyncscripts,
         deferScripts: commandLineOptions.deferscripts,
         cdnRoot: cdnRoot,
+        recursive: !commandLineOptions.norecursive,
         cdnFlash: !commandLineOptions.nocdnflash,
         cdnHtml: commandLineOptions.cdnhtml,
         noCompress: commandLineOptions.nocompress,

--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -67,18 +67,29 @@ module.exports = function (options) {
     return function buildProduction(assetGraph, cb) {
         var query = assetGraph.query;
 
-        assetGraph.followRelations =
-            query.or({
-                to: {type: 'I18n'}
-            },
-            {
-                type: 'HtmlAnchor',
-                to: /^file:/
-            },
-            {
-                type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl']),
-                to: {url: query.not(/^https?:/)}
-            });
+        if (options.recursive) {
+            assetGraph.followRelations =
+                query.or({
+                    to: {type: 'I18n'}
+                },
+                {
+                    type: 'HtmlAnchor',
+                    to: /^file:/
+                },
+                {
+                    type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl']),
+                    to: {url: query.not(/^https?:/)}
+                });
+        } else {
+            assetGraph.followRelations =
+                query.or({
+                    to: {type: 'I18n'}
+                },
+                {
+                    type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl', 'HtmlAnchor']),
+                    to: {url: query.not(/^https?:/)}
+                });
+        }
 
         assetGraph
             .populate({from: {type: 'Html'}, followRelations: {type: 'HtmlScript', to: {url: /^file:/}}})


### PR DESCRIPTION
The first commit makes the population query include relations to local html-files.

The second commit is a refactoring of the old logic, that was inside the `moveAssetsInOrder`-transform, out to the query object it gets as an argument. By not including files that we know aren't being renamed we avoid a lot of cyclic dependency issues when doing graph traversals. Even simple webpages with two html-pages linking to each other are cyclic, which made it break right out of the box before.
