### PR TITLE
add docker image support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends libcairo2-dev libgif-dev optipng pngcrush pngquant libpango1.0-dev graphicsmagick libjpeg-turbo-progs inkscape libvips-dev libgsf-1-dev
+RUN npm install -g assetgraph-builder
+
+ENTRYPOINT ["/usr/local/bin/buildProduction"]

--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ Looking for a Grunt integration? Try [grunt-reduce](https://github.com/Munter/gr
 Quick start
 -----------
 
+# Conventional
 ```
 npm install -g assetgraph-builder
 buildProduction path/to/your/index.html --outroot path/to/output/directory
+```
+
+# [Docker](https://www.docker.com/)
+```
+docker run --rm -it  -v "$(pwd)":/app/ -w /app/ assetgraph-builder path/to/your/index.html --outroot path/to/output/directory
 ```
 
 Congratulations, you just optimized your web page!


### PR DESCRIPTION
Instead of installing this project locally, I created a `Dockerfile` which builds an image that has everything ready to use. This is helpful to me because then I don't have to worry about installing and dependencies on my local system, I only need Docker installed correctly.

All you have to do is create a `assetgraph-builder` image on the [Docker Hub](https://registry.hub.docker.com/) and turn on [automated builds](https://docs.docker.com/docker-hub/builds/)

Let me know if you have any questions.
