### PR TITLE
Utility to find all files that aren't used for a production build.

### DIFF
--- a/bin/findUnusedAssets
+++ b/bin/findUnusedAssets
@@ -12,8 +12,23 @@ var _ = require('underscore'),
 
 var assetGraph = new AssetGraph({root: commandLineOptions.root});
 
+//Run external process
+function runEx(command, callback, scope) {
+    var exec = require('child_process').exec;
+    exec(command, function (error, stdout, stderr) {
+        if (stderr) {
+            console.log(command);
+            console.log('stderr: ' + stderr);
+        } else {
+            stdout = stdout.replace(/([\r\n]+|[\r]+|[\n]+)/g, '\n'); //Normalize
+            var output = stdout.split('\n'); //Array
+            callback.call(scope, output);
+        }
+    });
+}
+
 assetGraph.on('afterTransform', function (transform, elapsedTime) {
-        console.log((elapsedTime / 1000).toFixed(3) + " secs: " + transform.name);
+        console.log((elapsedTime / 1000).toFixed(3) + ' secs: ' + transform.name);
     })
     .on('warn', function (err) {
         // These are way too noisy
@@ -33,7 +48,7 @@ assetGraph.on('afterTransform', function (transform, elapsedTime) {
     .loadAssets(commandLineOptions._.map(urltools.fsFilePathToFileUrl))
     .populate({from: {type: 'Html'}, followRelations: {type: 'HtmlScript', to: {url: /^file:/}}})
     .assumeRequireJsConfigHasBeenFound()
-    .moveAssets({isInitial: true}, function (asset) {return asset.url.replace(/\.template$/, ""); })
+    .moveAssets({isInitial: true}, function (asset) {return asset.url.replace(/\.template$/, ''); })
     .populate({
         followRelations: {
             to: {url: assetGraph.query.not(/^https?:/)}
@@ -86,18 +101,3 @@ assetGraph.on('afterTransform', function (transform, elapsedTime) {
             }
         });
     });
-
-//Run external process
-function runEx(command, callback, scope) {
-    var exec = require('child_process').exec;
-    exec(command, function (error, stdout, stderr) {
-        if (stderr) {
-            console.log(command);
-            console.log('stderr: ' + stderr);
-        } else {
-            stdout = stdout.replace(/([\r\n]+|[\r]+|[\n]+)/g, '\n'); //Normalize
-            var output = stdout.split('\n'); //Array
-            callback.call(scope, output);
-        }
-    });
-}


### PR DESCRIPTION
This is a tool for finding unused assets in your code base.
The options are similar to bin/findOneInclude with an additional 'limitsearch' option, to limit the search to a specific directory in the root of the project (for example to exclude a directory that contains 3rd party libraries).
