### PR TITLE
User configurable followRelations in buildProduction

### DIFF
--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -76,28 +76,30 @@ module.exports = function (options) {
 
         assetGraph.javaScriptSerializationOptions = javaScriptSerializationOptions;
 
-        if (options.recursive) {
-            assetGraph.followRelations =
-                query.or({
-                    to: {type: 'I18n'}
-                },
-                {
-                    type: ['HtmlAnchor', 'HtmlMetaRefresh'],
-                    to: /^file:/
-                },
-                {
-                    type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl']),
-                    to: {url: query.not(/^https?:/)}
-                });
-        } else {
-            assetGraph.followRelations =
-                query.or({
-                    to: {type: 'I18n'}
-                },
-                {
-                    type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl', 'HtmlAnchor', 'HtmlMetaRefresh']),
-                    to: {url: query.not(/^https?:/)}
-                });
+        if (!assetGraph.followRelations) {
+            if (options.recursive) {
+                assetGraph.followRelations =
+                    query.or({
+                        to: {type: 'I18n'}
+                    },
+                    {
+                        type: ['HtmlAnchor', 'HtmlMetaRefresh'],
+                        to: /^file:/
+                    },
+                    {
+                        type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl']),
+                        to: {url: query.not(/^https?:/)}
+                    });
+            } else {
+                assetGraph.followRelations =
+                    query.or({
+                        to: {type: 'I18n'}
+                    },
+                    {
+                        type: query.not(['JavaScriptInclude', 'JavaScriptExtJsRequire', 'JavaScriptCommonJsRequire', 'SvgAnchor', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceUrl', 'HtmlAnchor', 'HtmlMetaRefresh']),
+                        to: {url: query.not(/^https?:/)}
+                    });
+            }
         }
 
         assetGraph


### PR DESCRIPTION
Programmatic usage of `transforms/buildProduction` is a bit cumbersome when it tries to be overly clever about what to populate