### PR TITLE
Switch to the node:0.10 docker image as base since 0.12 is currently unsupported

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:0.10
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends libcairo2-dev libgif-dev optipng pngcrush pngquant libpango1.0-dev graphicsmagick libjpeg-progs inkscape libvips-dev libgsf-1-dev


### PR DESCRIPTION
It should probably be changed back when support for Node 0.12 is added, but as it is right now the image for Assetgraph-builder on Docker Hub is broken.