### PR TITLE
i18nTools.tokenizePattern: Try to stringify the pattern if it's not a string, for more helpful error message

### DIFF
--- a/lib/i18nTools.js
+++ b/lib/i18nTools.js
@@ -23,7 +23,12 @@ i18nTools.expandLocaleIdToPrioritizedList = memoizeSync(function (localeId) {
 
 i18nTools.tokenizePattern = function (pattern) {
     if (typeof pattern !== 'string') {
-        throw new Error('i18nTools.tokenizePattern: Value must be a string: ' + pattern);
+        var valueString = pattern;
+        try {
+            valueString = JSON.stringify(pattern);
+        } catch(e) {
+        }
+        throw new Error('i18nTools.tokenizePattern: Value must be a string: ' + valueString);
     }
     var tokens = [],
         fragments = pattern.split(/(\{\d+\})/);


### PR DESCRIPTION
E.g. if an object like this one is passed:
{"one":"Foo {0}.","other":"Bar {0}."}

The error message is:
Error: importLanguageKeys transform: i18nTools.tokenizePattern: Value must be a string: [Object object]

Not sure if this is the best way to solve this, hence not directly landing on master.