### PR TITLE
Updated semver to version 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "plurals-cldr": "1.0.1",
     "pngcrush": "0.2.0",
     "pngquant": "0.6.0",
-    "semver": "4.3.3",
+    "semver": "5.0.3",
     "seq": "0.3.5",
     "temp": "0.8.1",
     "urltools": "0.2.0"


### PR DESCRIPTION
:rocket:

semver just published version 5.0.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 18 commits (ahead by 18, behind by 0).

- [5f89ecb](https://github.com/npm/node-semver/commit/5f89ecbe78145ad0b501cf6279f602a23c89738d): v5.0.3
- [fa88737](https://github.com/npm/node-semver/commit/fa88737011025c9f4ddcb74a9f4d0ea065f2beda): remove unused uglify-js
- [df967e1](https://github.com/npm/node-semver/commit/df967e1ad6251d0433b0398a93756142a423a528): v5.0.2
- [5d3a733](https://github.com/npm/node-semver/commit/5d3a73377cab9f18756ef7b2a934da0e5657de37): Update 'raw' when using inc() function
- [3408896](https://github.com/npm/node-semver/commit/3408896f115cdb241684fb81f85abb0d2ecc27e9): v5.0.1
- [61863fb](https://github.com/npm/node-semver/commit/61863fb3445680632456ffd87e1509e74b336a58): don't ignore build artifacts
- [01ac00c](https://github.com/npm/node-semver/commit/01ac00c45efa423894b2da5b043ce6190c96ae96): v5.0.0
- [41b56fa](https://github.com/npm/node-semver/commit/41b56fa573d1ef0d1718777a8a21ae1b57ebcd83): Remove all AMD/Browser/minified bits
- [63c4829](https://github.com/npm/node-semver/commit/63c48296ca5da3ba6a88c743bb8c92effc789811): v4.3.6
- [0a6c5da](https://github.com/npm/node-semver/commit/0a6c5da9864d2369f8c24f366dec1e7e44616c5b): npmignore: coverage stuff
- [75bb9e0](https://github.com/npm/node-semver/commit/75bb9e0692b562f296b0a353a7934e0510727566): v4.3.5
- [bca6db7](https://github.com/npm/node-semver/commit/bca6db73421265d79dbca942ead4ba3e0f163828): travis
- [108f38e](https://github.com/npm/node-semver/commit/108f38e0d69c3dc941baccd82b9d12471206cbec): Use new tap, ignore nyc/coverage output
- [aad3543](https://github.com/npm/node-semver/commit/aad3543b8c3f767f80ad3a194b281f900b488218): Fix for ltr and gtr when used with "*" range
- [93a8706](https://github.com/npm/node-semver/commit/93a870665bba0f4be5c4edc19d6f94ff39ad60e8): Fix for range "*" with a prerelease version


There are 18 commits in total. See the [full diff](https://github.com/npm/node-semver/compare/bb32a43bdfa7223e4c450d181e5a2184b00f24d4...5f89ecbe78145ad0b501cf6279f602a23c89738d).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>