### PR TITLE
Updated chalk to version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "assetgraph": "1.23.0",
     "async": "1.4.2",
     "browserslist": "0.1.3",
-    "chalk": "1.0.0",
+    "chalk": "1.1.1",
     "express-processimage": "2.6.1",
     "extend": "1.2.1",
     "jpegtran": "0.2.0",


### PR DESCRIPTION
:rocket:

chalk just published version 1.1.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/chalk/chalk/releases/tag/v1.1.1)

Fixes a very strange issue with using the same name for a variable and it's assigned function. https://github.com/chalk/chalk/issues/81

Probably a V8 bug.

---
The new version differs by 30 commits (ahead by 30, behind by 0).

- [8b554e2](https://github.com/chalk/chalk/commit/8b554e254e89c85c1fd04dcc444beeb15824e1a5): 1.1.1
- [409f95e](https://github.com/chalk/chalk/commit/409f95eef525bcee56d1baafcee0b8f18cb72349): add XO
- [fb6332d](https://github.com/chalk/chalk/commit/fb6332df4fc6838f6a789f8dfb9a3d13e6c9e97d): readme - add `wrap-ansi` to related section
- [5d2cefc](https://github.com/chalk/chalk/commit/5d2cefc24340f9b1b50b9117ee38b84c349bdf80): Merge pull request #81 from lukeapage/master
- [4006cc0](https://github.com/chalk/chalk/commit/4006cc0b4109df1c8fd7941c4871c8f8a66fbfad): Remove un-necessary function name. Fixes #80
- [6142553](https://github.com/chalk/chalk/commit/6142553bb5d7b3e7fbcea76b8ccf876f373e1bf1): updated # of dependents to ~4.5k
- [789a011](https://github.com/chalk/chalk/commit/789a0118c6577dab7ed0e59208bb0e97096a8f5f): Merge pull request #74 from danielhusar/patch-1
- [388e21a](https://github.com/chalk/chalk/commit/388e21aed744c37b5d5c4c102c0e2415edf725de): Fix typo in readme
- [d7537f3](https://github.com/chalk/chalk/commit/d7537f37df874619511994f1debf2ec6dbacaa3c): Merge branch 'master' of https://github.com/sindresorhus/chalk
- [632bd4a](https://github.com/chalk/chalk/commit/632bd4a088f0cb685179f66df73a3b687926f8bd): added Qix as maintainer
- [e9bb6e6](https://github.com/chalk/chalk/commit/e9bb6e6000b1c5d4508afabfdc85dd70f582f515): 1.1.0
- [ed03714](https://github.com/chalk/chalk/commit/ed03714ec28411c1c02fc6943a4dc224af7959c9): Bump ansi-styles version.
- [4d23b33](https://github.com/chalk/chalk/commit/4d23b33c9ef793ce1ff46cc0a1410b55638e4b30): Merge pull request #72 from chalk/issue/58
- [922ac4b](https://github.com/chalk/chalk/commit/922ac4b0aa67c42b7e0e79ca4a5a7c33beb3e858): Makes dim when gray a noop on windows terminals.
- [7d5955a](https://github.com/chalk/chalk/commit/7d5955a91aedaca4916f07569d6ae1d1ab0864fe): add reference to `chalk-cli


There are 30 commits in total. See the [full diff](https://github.com/chalk/chalk/compare/8864d3563313ed15574a38dd5c9d5966080c46ce...8b554e254e89c85c1fd04dcc444beeb15824e1a5).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>