### PR TITLE
Updated autoprefixer to version 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node-zopfli": "1.2.1"
   },
   "devDependencies": {
-    "autoprefixer": "5.2.0",
+    "autoprefixer": "6.0.3",
     "coveralls": "2.11.2",
     "gm": "1.17.0",
     "istanbul": "0.3.21",


### PR DESCRIPTION
:rocket:

autoprefixer just published version 6.0.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>