### PR TITLE
Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
 FROM node:0.10
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends libcairo2-dev libgif-dev optipng pngcrush pngquant libpango1.0-dev graphicsmagick libjpeg-progs inkscape libvips-dev libgsf-1-dev
-RUN npm install -g assetgraph-builder svgo
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        graphicsmagick \
+        inkscape \
+        libcairo2-dev \
+        libgif-dev \
+        libgsf-1-dev \
+        libjpeg-progs \
+        libpango1.0-dev \
+        libvips-dev \
+        optipng \
+        pngcrush \
+        pngquant \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g \
+    assetgraph-builder \
+    svgo
 
 ENTRYPOINT ["/usr/local/bin/buildProduction"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM node:0.10
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends libcairo2-dev libgif-dev optipng pngcrush pngquant libpango1.0-dev graphicsmagick libjpeg-progs inkscape libvips-dev libgsf-1-dev
-RUN npm install -g assetgraph-builder
+RUN npm install -g assetgraph-builder svgo
 
 ENTRYPOINT ["/usr/local/bin/buildProduction"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10
+FROM node:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
- Add `svgo` to the Docker image in order to provide SVG minification.
- Apply some [best practices](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get) around `apt-get` usage when building the Docker image.

I'm also wondering if the Node.js version for the Docker image could be bumped, it's currently at version 0.10, but I'm not sure which Node.js versions Assetgraph currently supports.
During a local test I did on a static site, using `node:latest` (Node.js 6.2.1) seemed to work fine.