### PR TITLE
Implement canonicalRoot option and deprecate canonicalUrl option

### DIFF
--- a/bin/buildProduction
+++ b/bin/buildProduction
@@ -28,13 +28,13 @@ var chalk = require('chalk'),
             type: 'string',
             demand: true
         })
-        .options('cdnroot', {
-            describe: 'URI root where the static assets will be deployed. Must be either an absolute or a protocol-relative url',
+        .options('canonicalroot', {
+            describe: 'URI root where the site will be deployed. Must be either an absolute or a protocol-relative url',
             type: 'string',
             demand: false
         })
-        .options('canonicalurl', {
-            describe: 'URI root where the project being built will be deployed (experimental)',
+        .options('cdnroot', {
+            describe: 'URI root where the static assets will be deployed. Must be either an absolute or a protocol-relative url',
             type: 'string',
             demand: false
         })
@@ -253,6 +253,12 @@ if (commandLineOptions.cdnoutroot) {
     console.warn(chalk.yellow('INFO: the --cdnoutroot switch is deprecated. Default location for your cdn assets is now <outroot>/static/cdn'));
 }
 
+// Temporary deprecation message
+if (commandLineOptions.canonicalurl) {
+    console.warn(chalk.red('INFO: the --canonicalurl switch is deprecated. Please use --canonicalroot for the same effect plus more features'));
+    process.exit(1);
+}
+
 var _ = require('lodash'),
     AssetGraph = require('../lib/AssetGraph'),
     query = AssetGraph.query,
@@ -260,7 +266,6 @@ var _ = require('lodash'),
     outRoot = urlTools.fsDirToFileUrl(commandLineOptions.outroot),
     cdnRoot = commandLineOptions.cdnroot && urlTools.ensureTrailingSlash(commandLineOptions.cdnroot),
     fullCdnRoot = (/^\/\//.test(cdnRoot) ? 'http:' : '') + cdnRoot,
-    canonicalUrl = commandLineOptions.canonicalurl && urlTools.ensureTrailingSlash(commandLineOptions.canonicalurl),
     rootUrl = commandLineOptions.root && urlTools.urlOrFsPathToUrl(commandLineOptions.root, true),
     reservedNames = commandLineOptions.reservednames && _.flatten(_.flatten([commandLineOptions.reservednames]).map(function (reservedName) {
         return reservedName.split(',');
@@ -398,11 +403,13 @@ var buildProductionOptions = {
     sharedBundles: commandLineOptions.sharedbundles,
     stripDebug: !commandLineOptions.debug,
     addInitialHtmlExtension: commandLineOptions.addinitialhtmlextension,
-    canonicalUrl: canonicalUrl,
     javaScriptSerializationOptions: javaScriptSerializationOptions
 };
 
-new AssetGraph({root: rootUrl})
+new AssetGraph({
+        root: rootUrl,
+        canonicalRoot: commandLineOptions.canonicalroot
+    })
     .queue(function (assetGraph) {
         plugins.forEach(function (plugin) {
             require(plugin)(assetGraph, buildProductionOptions, commandLineOptions);
@@ -428,7 +435,7 @@ new AssetGraph({root: rootUrl})
     .logEvents({repl: commandLineOptions.repl, stopOnWarning: commandLineOptions.stoponwarning, suppressJavaScriptCommonJsRequireWarnings: true})
     .loadAssets(inputUrls)
     .buildProduction(buildProductionOptions)
-    .writeAssetsToDisc({url: canonicalUrl ? query.createPrefixMatcher(canonicalUrl) : /^file:/, isLoaded: true}, outRoot, canonicalUrl)
+    .writeAssetsToDisc({url: /^file:/, isLoaded: true}, outRoot)
     .if(cdnRoot)
         .writeAssetsToDisc({url: query.createPrefixMatcher(fullCdnRoot), isLoaded: true}, outRoot + 'static/cdn/', fullCdnRoot)
     .endif()

--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -1,6 +1,5 @@
 /*eslint indent:0*/
-var urlTools = require('urltools'),
-    browsersList = require('browserslist');
+var browsersList = require('browserslist');
 
 module.exports = function (options) {
     options = options || {};
@@ -227,14 +226,20 @@ module.exports = function (options) {
                     })
                 .endif()
             .endif()
-            .if(options.canonicalUrl)
-                // Maybe this should be the effect of updating assetGraph.root?
-                .moveAssets({isLoaded: true, isInline: false}, function (asset, assetGraph) {
-                    if (asset.url.indexOf(assetGraph.root) === 0) {
-                        return assetGraph.resolveUrl(options.canonicalUrl, urlTools.buildRelativeUrl(assetGraph.root, asset.url));
+            .if(assetGraph.canonicalRoot)
+                .updateRelations({
+                    to: {
+                        isLoaded: true,
+                        isInline: false
+                    },
+                    from: {
+                        type: 'Html',
+                        isFragment: true,
+                        nonInlineAncestor: {
+                            type: ['Rss', 'Atom']
+                        }
                     }
-                })
-                .updateRelations({from: {type: 'Html', isFragment: true, nonInlineAncestor: {type: ['Rss', 'Atom']}}}, {hrefType: 'absolute'})
+                }, {canonical: true})
             .endif()
             .if(options.sourceMaps)
                 .serializeSourceMaps({ sourcesContent: options.sourcesContent })
@@ -294,7 +299,7 @@ module.exports = function (options) {
                             }
                         }
                     )), function (asset, assetGraph) {
-                        var targetUrl = (options.canonicalUrl || '/') + 'static/';
+                        var targetUrl = '/static/';
                         // Conservatively assume that all JavaScriptStaticUrl relations pointing at non-images are intended to be fetched via XHR
                         // and thus cannot be put on a CDN because of same origin restrictions:
                         if (options.cdnRoot && asset.type !== 'Htc' && asset.extension !== '.jar' && (asset.type !== 'Html' || options.cdnHtml) && (asset.isImage || assetGraph.findRelations({to: asset, type: 'JavaScriptStaticUrl'}).length === 0) || (options.cdnRoot && options.cdnFlash && asset.type === 'Flash')) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bin"
   ],
   "dependencies": {
-    "assetgraph": "3.0.0-21",
+    "assetgraph": "3.0.0-22",
     "async": "^2.0.0",
     "browserslist": "1.4.0",
     "chalk": "^1.1.3",


### PR DESCRIPTION
If I understand correctly, the caonicalRoot implementation is what the canonicalurl option was supposed to be all along. So I deprecated it in favor of canonicalRoot.

Some places this simplifies asset url handling, since we are no longer positioning the assets in the canonical root, but inly the relation hrefs.

The updated test case needed a conceptual rewrite to also test on href rather than asset urls