### PR TITLE
Actual Webpack 2 support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bin"
   ],
   "dependencies": {
-    "assetgraph": "3.0.0-47",
+    "assetgraph": "assetgraph/assetgraph#b1c4890bb000cc5f5d27de715b3307fb511acb79",
     "async": "^2.0.0",
     "browserslist": "1.7.1",
     "chalk": "^1.1.3",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,4 +2,4 @@
 --timeout 60000
 --recursive
 --check-leaks
---globals Promise,requirejsVars,curPart,i,out,_requirejsCssData,$__curScript,URLPolyfill,SystemJS,System,$traceurRuntime,traceur,Reflect,__cjsWrapper,define
+--globals requirejsVars,curPart,i,out


### PR DESCRIPTION
Requires a bit of coordination with https://github.com/assetgraph/assetgraph-builder/pull/513, which downgrades to webpack 1 and adds a dependency on `html-webpack-plugin`, which should probably be upgraded to 2.28.0+ as part of the Webpack 2 upgrade.