### PR TITLE
Fix Docker builds by not installing the module globally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,12 @@ RUN apt-get update \
         pngquant \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g \
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$NPM_CONFIG_PREFIX/bin:$PATH
+USER node
+
+RUN npm --loglevel=warn install -g \
     assetgraph-builder \
     svgo
 
-ENTRYPOINT ["/usr/local/bin/buildProduction"]
+ENTRYPOINT ["buildProduction"]


### PR DESCRIPTION
Changes to NPM has meant that the Docker builds stopped working as it no longer
will install stuff globally as root, meaning it runs into permission issues
during the package installation.

This adds a workaround which means the packages won't be installed globally,
but still will be available in `$PATH` and thus have the same effect.

The log level of NPM was also changed to "warn" in order to avoid debug output
about fetching package information and files from the NPM registry.