### PR TITLE
Remove the node-zopfli dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "pngquant": "1.3.0",
     "urltools": "0.4.1"
   },
-  "optionalDependencies": {
-    "node-zopfli": "2.0.2"
-  },
   "devDependencies": {
     "autoprefixer": "^9.0.0",
     "coveralls": "^3.0.0",


### PR DESCRIPTION
It's really noisy at install time, and the gzip transform already falls back to gzip in a graceful way.

Follow-up from https://github.com/assetgraph/assetgraph-builder/pull/633