### PR TITLE
ci: test on Node.js 8, 10 and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - "8"
-  - "9"
   - "10"
+  - "node"
 env:
   - CXX=g++-4.8
 addons:


### PR DESCRIPTION
Node.js 9 was a shortliving release branch like all odd major release numbers.
We should only test the even LTS and the current latest release numbers.

Also see https://github.com/nodejs/Release/blob/master/README.md