### PR TITLE
Always run autoprefixer if it's available

### DIFF
--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -9,13 +9,10 @@ module.exports = function(options) {
   const minify = typeof options.minify === 'undefined' ? true : options.minify;
 
   let selected;
-  let browsersExplicitlyGiven = false;
   if (options.browsers) {
     selected = browsersList(options.browsers);
-    browsersExplicitlyGiven = true;
   } else if (browsersList.findConfig('.')) {
     selected = browsersList();
-    browsersExplicitlyGiven = true;
   } else {
     // Default to all browsers
     selected = browsersList('last 999 versions');
@@ -316,8 +313,7 @@ module.exports = function(options) {
 
     await assetGraph.autoprefixer(browsers.selected, {
       sourceMaps: options.sourceMaps,
-      sourcesContent: options.sourcesContent,
-      errorIfNotFound: browsersExplicitlyGiven
+      sourcesContent: options.sourcesContent
     });
 
     if (options.addInitialHtmlExtension) {

--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -8,60 +8,55 @@ module.exports = function(options) {
 
   const minify = typeof options.minify === 'undefined' ? true : options.minify;
 
-  // Default to try to support all browsers
-  let browsers = {
-    has() {
-      return true;
-    },
-    minimum() {
-      return 1;
-    }
-  };
-
   let selected;
+  let browsersExplicitlyGiven = false;
   if (options.browsers) {
     selected = browsersList(options.browsers);
+    browsersExplicitlyGiven = true;
   } else if (browsersList.findConfig('.')) {
     selected = browsersList();
+    browsersExplicitlyGiven = true;
+  } else {
+    // Default to all browsers
+    selected = browsersList('last 999 versions');
   }
-  if (selected) {
-    browsers = {
-      selected,
-      has(browserOrBrowsers) {
-        try {
-          return browsersList(browserOrBrowsers).some(browser =>
-            browsers.selected.some(
-              selectedBrowser =>
-                selectedBrowser === browser ||
-                selectedBrowser.indexOf(browser + ' ') === 0
-            )
+
+  let browsers = {
+    selected,
+    has(browserOrBrowsers) {
+      try {
+        return browsersList(browserOrBrowsers).some(browser =>
+          browsers.selected.some(
+            selectedBrowser =>
+              selectedBrowser === browser ||
+              selectedBrowser.indexOf(browser + ' ') === 0
+          )
+        );
+      } catch (e) {
+        // Parse error, try to match it as a browser name (any version) so that
+        // browsers.has('ie') does the expected.
+        return browsers.selected.some(selectedBrowser =>
+          selectedBrowser.startsWith(browserOrBrowsers + ' ')
+        );
+      }
+    },
+    // Find the minimum version of a given browser that is to be supported.
+    // For example: browsers.minimum('ie'); // 10
+    minimum(browser) {
+      let minimumVersion = null;
+      for (const selectedBrowser of browsers.selected) {
+        if (selectedBrowser.startsWith(browser + ' ')) {
+          const version = parseFloat(
+            selectedBrowser.substr(browser.length + 1)
           );
-        } catch (e) {
-          // Parse error, try to match it as a browser name (any version) so that
-          // browsers.has('ie') does the expected.
-          return browsers.selected.some(selectedBrowser =>
-            selectedBrowser.startsWith(browserOrBrowsers + ' ')
-          );
-        }
-      },
-      // Find the minimum version of a given browser that is to be supported.
-      // For example: browsers.minimum('ie'); // 10
-      minimum(browser) {
-        let minimumVersion = null;
-        for (const selectedBrowser of browsers.selected) {
-          if (selectedBrowser.startsWith(browser + ' ')) {
-            const version = parseFloat(
-              selectedBrowser.substr(browser.length + 1)
-            );
-            if (minimumVersion === null || version < minimumVersion) {
-              minimumVersion = version;
-            }
+          if (minimumVersion === null || version < minimumVersion) {
+            minimumVersion = version;
           }
         }
-        return minimumVersion;
       }
-    };
-  }
+      return minimumVersion;
+    }
+  };
 
   const bundleStrategyName = options.sharedBundles
     ? 'sharedBundles'
@@ -319,12 +314,11 @@ module.exports = function(options) {
       type: { $in: ['JavaScript', 'Css'] }
     });
 
-    if (options.browsers) {
-      await assetGraph.autoprefixer(options.browsers, {
-        sourceMaps: options.sourceMaps,
-        sourcesContent: options.sourcesContent
-      });
-    }
+    await assetGraph.autoprefixer(browsers.selected, {
+      sourceMaps: options.sourceMaps,
+      sourcesContent: options.sourcesContent,
+      errorIfNotFound: browsersExplicitlyGiven
+    });
 
     if (options.addInitialHtmlExtension) {
       // Add initial html extension

--- a/test/bin/buildProduction.js
+++ b/test/bin/buildProduction.js
@@ -1,10 +1,10 @@
-var expect = require('../unexpected-with-plugins');
-var pathModule = require('path');
-var Promise = require('bluebird');
-var rimrafAsync = Promise.promisify(require('rimraf'));
-var fs = Promise.promisifyAll(require('fs'));
-var getTemporaryFilePath = require('gettemporaryfilepath');
-var childProcess = Promise.promisifyAll(require('child_process'), {
+const expect = require('../unexpected-with-plugins');
+const pathModule = require('path');
+const Promise = require('bluebird');
+const rimrafAsync = Promise.promisify(require('rimraf'));
+const fs = Promise.promisifyAll(require('fs'));
+const getTemporaryFilePath = require('gettemporaryfilepath');
+const childProcess = Promise.promisifyAll(require('child_process'), {
   multiArgs: true
 });
 
@@ -154,6 +154,49 @@ describe('buildProduction', function() {
 
     try {
       expect(builtIndexHtml, 'to contain', "foo['catch']=123");
+    } finally {
+      await rimrafAsync(tmpDir);
+    }
+  });
+
+  it('should run autoprefixer when no --browsers is passed', async function() {
+    const tmpDir = getTemporaryFilePath();
+    await expect(
+      [
+        pathModule.resolve(__dirname, '..', '..', 'bin', 'buildProduction'),
+        '--root',
+        pathModule.resolve(
+          __dirname,
+          '..',
+          '..',
+          'testdata',
+          'bin',
+          'buildProduction',
+          'autoprefixer'
+        ),
+        '-o',
+        tmpDir,
+        pathModule.resolve(
+          __dirname,
+          '..',
+          '..',
+          'testdata',
+          'bin',
+          'buildProduction',
+          'autoprefixer',
+          'index.html'
+        )
+      ],
+      'run as a shell command'
+    );
+
+    const builtIndexHtml = await fs.readFileAsync(
+      pathModule.resolve(tmpDir, 'index.html'),
+      'utf-8'
+    );
+
+    try {
+      expect(builtIndexHtml, 'to contain', '::-ms-input-placeholder');
     } finally {
       await rimrafAsync(tmpDir);
     }

--- a/testdata/bin/buildProduction/autoprefixer/index.html
+++ b/testdata/bin/buildProduction/autoprefixer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+  ::placeholder {
+    color: gray;
+  }
+  </style>
+</head>
+<body></body>
+</html>


### PR DESCRIPTION
Also, pass the right set of browsers when defaulting to all browsers or when reading from `.browserslistrc`

Requires assetgraph/assetgraph#987