### PR TITLE
Remove buildProduction --subsetfonts

### DIFF
--- a/bin/buildProduction
+++ b/bin/buildProduction
@@ -70,12 +70,6 @@ const optimist = require('optimist')
     type: 'boolean',
     default: false
   })
-  .options('subsetfonts', {
-    describe:
-      'Whether to automatically create smaller webfont subsets with the statically decidable characters',
-    type: 'boolean',
-    default: false
-  })
   .options('webpackconfig', {
     describe:
       'Path to where your webpack config resides. Will be loaded using require.main.require',
@@ -516,7 +510,6 @@ const buildProductionOptions = {
   browsers: browsers,
   sourceMaps: commandLineOptions.sourcemaps,
   sourcesContent: commandLineOptions.sourcescontent,
-  subsetFonts: commandLineOptions.subsetfonts,
   contentSecurityPolicy: commandLineOptions.contentsecuritypolicy,
   contentSecurityPolicyLevel: commandLineOptions.contentsecuritypolicylevel,
   subResourceIntegrity: commandLineOptions.subresourceintegrity,

--- a/lib/transforms/buildProduction.js
+++ b/lib/transforms/buildProduction.js
@@ -574,10 +574,6 @@ module.exports = function(options) {
       );
     }
 
-    if (options.subsetFonts) {
-      await assetGraph.subsetFonts(options.subsetFonts);
-    }
-
     if (!options.noFileRev) {
       await assetGraph.moveAssetsInOrder(
         moveAssetsInOrderQuery,


### PR DESCRIPTION
Since we're planning to move all the font subsetting-related code into subfont itself, we'll have to part with `buildProduction --subsetfonts` and just have users apply subfont to the `buildProduction` output instead.