### PR TITLE
Fix the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gm-papandreou": "^1.23.0-patch1",
     "histogram": "^3.0.1",
     "impro": "~0.7.0",
+    "inkscape": "^2.0.0",
     "jpegtran": "^1.0.6",
     "lodash": "^4.14.1",
     "memoizesync": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "passerror": "^1.1.1",
     "pngcrush": "^2.0.1",
     "pngquant": "^3.0.0",
+    "sharp": "^0.23.4",
     "urltools": "^0.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "chalk": "^4.0.0",
     "esanimate": "^1.1.0",
     "estraverse": "^5.0.0",
-    "express-processimage": "^9.0.0",
     "extend": "^3.0.0",
     "histogram": "^3.0.1",
     "impro": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "chalk": "^4.0.0",
     "esanimate": "^1.1.0",
     "estraverse": "^5.0.0",
+    "express-processimage": "^9.0.0",
     "extend": "^3.0.0",
     "histogram": "^3.0.1",
     "impro": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "esanimate": "^1.1.0",
     "estraverse": "^5.0.0",
     "extend": "^3.0.0",
+    "gm-papandreou": "^1.23.0-patch1",
     "histogram": "^3.0.1",
     "impro": "~0.7.0",
     "jpegtran": "^1.0.6",

--- a/test/transforms/processImages.js
+++ b/test/transforms/processImages.js
@@ -29,12 +29,12 @@ describe('processImages', function () {
       [
         urlTools.resolveUrl(
           assetGraph.root,
-          'purplealpha24bit.pngquant-speed11.png'
+          'purplealpha24bit.pngquant-ncolors11.png'
         ),
         urlTools.resolveUrl(assetGraph.root, 'redalpha24bit.png?irrelevant'),
         urlTools.resolveUrl(
           assetGraph.root,
-          'redalpha24bit.pngquant-speed5.png'
+          'redalpha24bit.pngquant-ncolors5.png'
         ),
       ]
     );
@@ -343,7 +343,7 @@ it('should handle a test case with a couple of pngs', async function () {
   );
 
   const redAlpha24BitPngquanted = assetGraph.findAssets({
-    fileName: 'redalpha24bit.pngquant-speed5.png',
+    fileName: 'redalpha24bit.pngquant-ncolors5.png',
   })[0];
   expect(_.toArray(redAlpha24BitPngquanted.rawSrc.slice(0, 4)), 'to equal', [
     0x89,


### PR DESCRIPTION
It seems like https://github.com/assetgraph/assetgraph-builder/pull/721 caused the test suite to fail due to some missing dependencies, but it ran fine on CI at that point. I think Travis' caching feature is screwing us over.