### PR TITLE
Use Node.js v14 for Docker image, not the latest one (v15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:14
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -11,7 +11,8 @@ ENV PATH=$NPM_CONFIG_PREFIX/bin:$PATH
 USER node
 
 RUN npm --loglevel=warn install -g \
-    assetgraph-builder \
-    svgo
+        assetgraph-builder \
+        svgo \
+    && npm cache clean --force
 
 ENTRYPOINT ["buildProduction"]


### PR DESCRIPTION
This fixes building of the Docker image, which otherwise fails because the node-canvas dependency doesn't have a prebuilt version available for Node.js v15, and the image doesn't have the necessary system-level dependencies to
build it from source.

Using Node.js v14 (the latest LTS version) fixes this as we then can use the prebuilt node-canvas binary.

As a bonus I have also added clearing of the NPM cache after installing packages, this will decrease the final image size slightly.